### PR TITLE
Use the local ldap directory for user authentication by default

### DIFF
--- a/configuration/controller/sssd/sssd.conf
+++ b/configuration/controller/sssd/sssd.conf
@@ -18,7 +18,7 @@ chpass_provider = ldap
 cache_credentials = true
 entry_cache_timeout = 600
 ldap_uri = ldaps://{{ controller }}/
-ldap_search_base = dc=cluster
+ldap_search_base = dc=local
 ldap_tls_reqcert = never
 ldap_network_timeout = 30
 enumerate = true


### PR DESCRIPTION
This will fix issue #84 where regular users could not update their
own passwords.

This change will need to be reverted in order for authentication
with remote ldap directories to work (and, of course, the remote
directory will need to be configured).
