### PR TITLE
Rsync is not part of @Base

### DIFF
--- a/configuration/controller/local-repos.pkglist
+++ b/configuration/controller/local-repos.pkglist
@@ -1,0 +1,2 @@
+# rsync is not path of @Base group
+rsync


### PR DESCRIPTION
On secondary node local repos will be failed to set up if rsync is not installed.