### PR TITLE
Slurm PAM

### DIFF
--- a/configuration/controller/ansible/site/group_vars/all
+++ b/configuration/controller/ansible/site/group_vars/all
@@ -75,6 +75,12 @@ ssl_cert_group: ssl
 selinux_enabled: false
 
 
+# Whether or not to enable Slurm PAM module
+# If enabled, sssd's ldap filters will be disabled on the compute nodes
+
+slurm_pam_enabled: true
+
+
 # The default name to use when creating an image
 
 image_name: compute

--- a/configuration/controller/ansible/site/image.yml
+++ b/configuration/controller/ansible/site/image.yml
@@ -59,6 +59,7 @@
       sss_allowed_groups:
         - 'admins'
       sss_ldap_hostname: '{{ trix_ctrl_hostname }}.{{ trix_domain }}'
+      sss_filter_enabled: '{{ not slurm_pam_enabled }}'
       tags: sssd
 
     - role: slurm

--- a/configuration/controller/ansible/site/roles/slurm/defaults/main.yml
+++ b/configuration/controller/ansible/site/roles/slurm/defaults/main.yml
@@ -28,6 +28,8 @@ slurm_ctrl: 'controller'
 slurm_ctrl_ip: '127.0.0.1'
 slurm_ctrl_list: 'controller1,controller2'
 
+slurm_pam_enabled: false
+
 slurmdbd_sql_user: 'slurm_accounting'
 slurmdbd_sql_db: 'slurm_accounting'
 

--- a/configuration/controller/ansible/site/roles/slurm/files/pam-slurm
+++ b/configuration/controller/ansible/site/roles/slurm/files/pam-slurm
@@ -1,0 +1,3 @@
+auth      required     pam_localuser.so
+account   required     pam_unix.so
+session   required     pam_limits.so

--- a/configuration/controller/ansible/site/roles/slurm/files/pam-sshd
+++ b/configuration/controller/ansible/site/roles/slurm/files/pam-sshd
@@ -1,0 +1,22 @@
+#%PAM-1.0
+auth       required     pam_sepermit.so
+auth       substack     password-auth
+auth       include      postlogin
+# Used with polkit to reauthorize users in remote sessions
+-auth      optional     pam_reauthorize.so prepare
+account    required     pam_nologin.so
+# Enable slurm-pam controls
+account    required     pam_slurm.so
+account    include      password-auth
+password   include      password-auth
+# pam_selinux.so close should be the first session rule
+session    required     pam_selinux.so close
+session    required     pam_loginuid.so
+# pam_selinux.so open should only be followed by sessions to be executed in the user context
+session    required     pam_selinux.so open env_params
+session    required     pam_namespace.so
+session    optional     pam_keyinit.so force revoke
+session    include      password-auth
+session    include      postlogin
+# Used with polkit to reauthorize users in remote sessions
+-session   optional     pam_reauthorize.so prepare

--- a/configuration/controller/ansible/site/roles/slurm/tasks/main.yml
+++ b/configuration/controller/ansible/site/roles/slurm/tasks/main.yml
@@ -101,20 +101,38 @@
     daemon_reload: yes
     name: '{{ item }}'
     enabled: yes
-  when: not ha|default(False) and primary|default(False)
+  when: not ha|default(False)
+        and primary|default(True)
+        and ansible_connection not in 'lchroot'
+        and not compute|default(False)
   with_items:
     - munge
     - slurmdbd
     - slurmctld
 
-- name: Enable slurm compute services
-  file:
-    src: '{{ item.src }}'
-    dest: '{{ item.dest }}'
-    state: link
-  with_items:
-    - { src: '/usr/lib/systemd/system/munge.service', dest: '/etc/systemd/system/multi-user.target.wants/munge.service' }
-    - { src: '/usr/lib/systemd/system/slurmd.service', dest: '/etc/systemd/system/multi-user.target.wants/slurmd.service' }
+- block:
+
+  - name: Enable slurm compute services
+    file:
+      src: '{{ item.src }}'
+      dest: '{{ item.dest }}'
+      state: link
+    with_items:
+      - { src: '/usr/lib/systemd/system/munge.service', dest: '/etc/systemd/system/multi-user.target.wants/munge.service' }
+      - { src: '/usr/lib/systemd/system/slurmd.service', dest: '/etc/systemd/system/multi-user.target.wants/slurmd.service' }
+  
+  - name: Update PAM configuration to enable slurm pam controls
+    copy:
+      src: '{{ item.0 }}'
+      dest: '/etc/pam.d/{{ item.1 }}'
+      owner: root
+      group: root
+      mode: 0644
+    with_together:
+      - [ 'pam-sshd', 'pam-slurm']
+      - [ 'sshd', 'slurm' ]
+    when: slurm_pam_enabled
+
   when: ansible_connection in 'lchroot' or compute|default(False)
 
 - name: Start slurm compute services

--- a/configuration/controller/ansible/site/roles/slurm/tasks/main.yml
+++ b/configuration/controller/ansible/site/roles/slurm/tasks/main.yml
@@ -195,6 +195,12 @@
       - slurm.conf
     notify: restart slurm
   
+  - name: Set UsePAM to 1 in slurm-user.conf
+    lineinfile:
+      path: '{{ slurm_conf_path }}/slurm-user.conf'
+      line: 'UsePAM=1'
+    when: slurm_pam_enabled
+
   - name: Start slurm controller services
     service:
       daemon_reload: yes

--- a/configuration/controller/ansible/site/roles/sssd/defaults/main.yml
+++ b/configuration/controller/ansible/site/roles/sssd/defaults/main.yml
@@ -9,3 +9,5 @@ sss_allowed_groups:
   - admins
 
 sss_ldap_hostname: 'controller.cluster'
+
+sss_filter_enabled: true

--- a/configuration/controller/ansible/site/roles/sssd/templates/sssd.conf
+++ b/configuration/controller/ansible/site/roles/sssd/templates/sssd.conf
@@ -30,8 +30,10 @@ ldap_uri = ldaps://{{ sss_ldap_hostname }}/
 ldap_search_base = dc=local
 ldap_network_timeout = 30
 
-ldap_access_order = filter,expire
+ldap_access_order = {% if sss_filter_enabled %}filter,{% endif %}expire
 ldap_access_filter = {% for group in sss_allowed_groups %} (memberOf=cn=admins,ou={{ group }},dc=local) {% endfor %}
+
+
 ldap_account_expire_policy = shadow
 
 enumerate = true


### PR DESCRIPTION
Add support for slurm PAM controls on the cluster
If enabled, sssd ldap filters will be automatically disabled on the compute nodes to prevent slurm/sssd from stepping on each other's toes.