### PR TITLE
Update slurm-user.conf to have a more sensible QoS weight

### DIFF
--- a/site/roles/trinity/slurm/files/slurm-user.conf
+++ b/site/roles/trinity/slurm/files/slurm-user.conf
@@ -1,5 +1,5 @@
 PriorityType=priority/multifactor
-PriorityWeightQOS=1
+PriorityWeightQOS=10000  # All weights are mutiplied by a value between 0 and 1 and then converted back to a 32 bit unsigned int so make them all big enough not to lose precision
 #JobAcctGatherFrequency=15
 #JobAcctGatherType=jobacct_gather/linux
 PreemptType=preempt/none


### PR DESCRIPTION
PriorityWeightQOS in SLURM (like all the weights) is multiplied by a float between 0 and 1 and then cast back into an unsigned integer. The old default of one will truncate back to zero in all case. Updated this to default to 10000 and added a comment that all should be similar numbers.