### PR TITLE
obol: specify home directory

### DIFF
--- a/site/roles/trinity/obol/files/obol
+++ b/site/roles/trinity/obol/files/obol
@@ -66,7 +66,7 @@ def exists(key, value):
 
 
 def user_add(b, username, cn, sn, givenName, password, uid, gid, mail, phone,
-             shell, group, groups, expire):
+             shell, home, group, groups, expire):
     """Add a user to the LDAP directory"""
 
     if uid:
@@ -102,7 +102,7 @@ def user_add(b, username, cn, sn, givenName, password, uid, gid, mail, phone,
     if not sn:
         sn = username
 
-    home = load_param("users", "home") + '/' + username
+    home = home if home else load_param("users", "home") + '/' + username
     shell = shell if shell else load_param("users", "shell")
 
     if expire and expire != '-1':
@@ -250,6 +250,9 @@ def user_modify(b, username, **kwargs):
 
             if value != '-1':
                 value = str(int(value) + int(time.time() / 86400))
+
+        elif key == 'home':
+            key = 'homeDirectory'
 
         if append:
             mod_attrs.append((ldap.MOD_REPLACE, key, value))
@@ -454,6 +457,7 @@ command.add_argument('--gid', metavar='GROUP ID')
 command.add_argument('--mail', metavar="EMAIL ADDRESS")
 command.add_argument('--phone', metavar="PHONE NUMBER")
 command.add_argument('--shell')
+command.add_argument('--home')
 command.add_argument('--groups', type=csep,
                      help='A comma separated list of group names')
 command.add_argument('--expire', metavar="DAYS",
@@ -475,6 +479,7 @@ command.add_argument('--givenName')
 command.add_argument('--uid', metavar='USER ID')
 command.add_argument('--gid', metavar='GROUP ID')
 command.add_argument('--shell')
+command.add_argument('--home')
 command.add_argument('--mail', metavar="EMAIL ADDRESS")
 command.add_argument('--phone', metavar="PHONE NUMBER")
 command.add_argument('--expire', metavar="DAYS",


### PR DESCRIPTION
Add an option to set the home directory during user creation or modify it later. 
Useful if the location needs to be non-default or it has been changed after creating a user.