### PR TITLE
This introduces support for auto-registration of hosts in Zabbix...

### DIFF
--- a/site/controller.yml
+++ b/site/controller.yml
@@ -175,10 +175,11 @@
       zabbix_sql_db: 'zabbix'
       tags: zabbix
 
-    - role: trinity/zabbix_agent
-      tags: zabbix_agent
+#    - role: trinity/zabbix_agent
+#      tags: zabbix_agent
 
     - role: trinity/zabbix_checks
+      zabbix_hostmetadata: controller
       tags: zabbix_checks
 
     - role: trinity/trix-status

--- a/site/library/zabbix_conf.py
+++ b/site/library/zabbix_conf.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 from ansible.module_utils.basic import AnsibleModule
-from zabbix_api.zabbix_api import ZabbixAPIException, ZabbixAPI
+from zabbix_api import ZabbixAPI,ZabbixAPIException
 import xml.etree.ElementTree as ET
 
 
@@ -47,7 +47,7 @@ def main():
         conf_object = getattr(zapi, module.params["object"])
         msg = []
 
-        # Firt handle objcects witout 'get' method
+        # First handle objects witout 'get' method
 
         # 'configuration'
         if module.params["object"] == "configuration":

--- a/site/roles/trinity/zabbix/tasks/main.yml
+++ b/site/roles/trinity/zabbix/tasks/main.yml
@@ -174,7 +174,7 @@
     retries: 5
     delay: 10
 
-  - name: Aquire zabbix Admin password (generate or use one from /etc/trinity/passwords)
+  - name: Acquire zabbix Admin password (generate or use one from /etc/trinity/passwords)
     set_fact:
       zabbix_admin_pwd: "{{ lookup('password',
                             '/etc/trinity/passwords/zabbix/admin.txt
@@ -216,7 +216,7 @@
 ###############################################################################
 #  Get token
 
-  - name: Aquire token
+  - name: Acquire token
     uri:
       url: 'https://localhost/zabbix/api_jsonrpc.php'
       validate_certs: no
@@ -261,89 +261,6 @@
     fail:
       msg: 'Error on previos step: {{ res.json.error }}'
     when: res.json.error is defined
-
-###############################################################################
-#  Node auto registration
-
-  - name: Fetch status of auto registration
-    uri:
-      url: 'https://localhost/zabbix/api_jsonrpc.php'
-      validate_certs: no
-      body_format: json
-      body: '{
-            "jsonrpc": "2.0",
-            "method": "action.get",
-            "auth": "{{ zabbix_auth_token }}",
-            "id": 3,
-            "params": {
-                "filter": {
-                    "name": "Auto registration"
-                }
-            }
-        }'
-    ignore_errors: true
-    register: auto_reg_exists
-
-  # 10102 Template App SSH Service
-  # 10186 Template ICMP Ping
-  # 10001 Template OS Linux
-  - name: Enable automatic registration of zabbix agents
-    uri:
-      url: 'https://localhost/zabbix/api_jsonrpc.php'
-      validate_certs: no
-      body_format: json
-      body: '{
-            "jsonrpc": "2.0",
-            "method": "action.create",
-            "auth": "{{ zabbix_auth_token }}",
-            "id": 3,
-            "params": {
-                "name": "Auto registration",
-                "eventsource": 2,
-                "evaltype": 0,
-                "def_shortdata": "Auto registration: {HOST.HOST}",
-                "def_longdata": "Host name: {HOST.HOST}\nHost IP: {HOST.IP}\nAgent port: {HOST.PORT}",
-                "conditions": [
-                    {
-                        "conditiontype": 22,
-                        "operator": 2,
-                        "value": ""
-                    }
-                ],
-                "operations": [
-                    {
-                        "operationtype": 2
-                    },
-                    {
-                        "operationtype": 4,
-                        "opgroup": [
-                            {"groupid": "5"},
-                            {"groupid": "2"}
-                        ]
-                    },
-                    {
-                        "operationtype": 6,
-                        "optemplate": [
-                            {"templateid": "10102"},
-                            {"templateid": "10186"},
-                            {"templateid": "10001"}
-                        ]
-                    }
-                ]
-            }
-        }'
-    register: res
-    changed_when: res.json.result != {}
-    when:
-      - auto_reg_exists.json.result is defined
-      - auto_reg_exists.json.result == []
-
-  - name: Check for error
-    fail:
-      msg: 'Error on previos step: {{ res.json.error }}'
-    when:
-      - res.skipped is not defined
-      - res.json.error is defined
 
 ###############################################################################
 #  Send notifications
@@ -483,12 +400,12 @@
     register: hk
     changed_when: false
 
-  - name: Set trends houskeeping
+  - name: Set trends housekeeping
     shell: >
       echo "update {{ zabbix_sql_db }}.config set hk_trends_global=1" | mysql
     when: hk.stdout_lines[0] == '0'
 
-  - name: Set history houskeeping
+  - name: Set history housekeeping
     shell: >
       echo "update {{ zabbix_sql_db }}.config set hk_history_global=1" | mysql
     when: hk.stdout_lines[1] == '0'

--- a/site/roles/trinity/zabbix_agent/templates/zabbix_agentd.conf.j2
+++ b/site/roles/trinity/zabbix_agent/templates/zabbix_agentd.conf.j2
@@ -12,3 +12,5 @@ ServerActive={{ trix_ctrl_ip }}
 {% endif %}
 Include=/etc/zabbix/zabbix_agentd.d/*.conf
 UnsafeUserParameters=1
+HostMetadata={{ zabbix_hostmetadata }}
+

--- a/site/roles/trinity/zabbix_checks/tasks/main.yml
+++ b/site/roles/trinity/zabbix_checks/tasks/main.yml
@@ -11,12 +11,13 @@
       name: MySQL-python
       state: present
 
-  - name: Aquire zabbix SQL password (generate or use one from /etc/trinity/passwords)
+  - name: Acquire zabbix SQL password (generate or use one from /etc/trinity/passwords)
     set_fact:
       zabbix_sql_pwd: "{{ lookup('password',
                         '/etc/trinity/passwords/mysql/zabbix.txt
                          chars=ascii_letters,digits,hexdigits') }}"
-  - name: Aquire zabbix Admin password (generate or use one from /etc/trinity/passwords)
+
+  - name: Acquire zabbix Admin password (generate or use one from /etc/trinity/passwords)
     set_fact:
       zabbix_admin_pwd: "{{ lookup('password',
                         '/etc/trinity/passwords/zabbix/admin.txt
@@ -28,7 +29,7 @@
         mysql --user=zabbix --password={{ zabbix_sql_pwd }}
         --database=zabbix --host=localhost --batch --skip-column-names
 
-  - name: Check if regexp exist in zabbix DB
+  - name: Check if regexp exists in zabbix DB
     command: >
       {{ cmd_sql }}
       --execute="SELECT * FROM regexps WHERE \
@@ -45,7 +46,7 @@
                     ( {{ zabbix_checks_sql_regexpid }}, \"Mounts\", \"\");"
     when: zabb_select_regexp_out.stdout != "1000\tMounts\t"
 
-  - name: Check if expression exist in zabbix DB
+  - name: Check if expression exists in zabbix DB
     command: >
       {{ cmd_sql }}
       --execute="SELECT * FROM expressions WHERE \
@@ -101,25 +102,9 @@
             createMissing: true
         source: "{{ lookup('file', item )}}"
     with_fileglob:
+      - "/usr/lib/zabbix/templates/00*.xml"
       - "/usr/lib/zabbix/templates/01*.xml"
       - "/usr/lib/zabbix/templates/02*.xml"
-      - "/usr/lib/zabbix/templates/*.xml"
-
-  - name: Get template IDs
-    zabbix_conf:
-      username: "Admin"
-      password: "{{ zabbix_admin_pwd  }}"
-      hostname: "localhost"
-      validate_certs: no
-      proto: "https"
-      object:   "{{item.object}}"
-      action:   "{{item.action}}"
-      filter:   "{{item.filter}}"
-    with_items:
-      - {object: "template", action: "get", filter: { host: "CV Controller" }   }
-      - {object: "template", action: "get", filter: { host: "Template App SSH Service" }   }
-      - {object: "template", action: "get", filter: { host: "Template ICMP Ping" }   }
-    register: templates
 
   - name: Configuring mail forwarding, creating host groups
     zabbix_conf:
@@ -128,16 +113,86 @@
       hostname: "localhost"
       proto: "https"
       validate_certs: no
-      object:   "{{item.object}}"
-      action:   "{{item.action}}"
-      filter:   "{{item.filter}}"
-      params:   "{{item.params}}"
+      object:   "{{ item.object }}"
+      action:   "{{ item.action }}"
+      filter:   "{{ item.filter }}"
+      params:   "{{ item.params }}"
     with_items:
-      - {object: "mediatype", action: "set", filter: { description: "Local e-mail" } , params: { smtp_server: "127.0.0.1" } }
-      - {object: "hostgroup", action: "set", filter: { }, params: { name: "Compute" } }
-      - {object: "hostgroup", action: "set", filter: { }, params: { name: "Controller" } }
-      - {object: "hostgroup", action: "set", filter: { }, params: { name: "Login" } }
-      - {object: "hostgroup", action: "set", filter: { }, params: { name: "Storage" } }
+      - { object: "mediatype", action: "set", filter: { description: "Local e-mail" } , params: { smtp_server: "127.0.0.1" } }
+      - { object: "hostgroup", action: "set", filter: { }, params: { name: "Compute" } }
+      - { object: "hostgroup", action: "set", filter: { }, params: { name: "Controller" } }
+      - { object: "hostgroup", action: "set", filter: { }, params: { name: "Login" } }
+      - { object: "hostgroup", action: "set", filter: { }, params: { name: "Storage" } }
+
+  - name: "Create or update (HA) controller host"
+    local_action: 
+      module: zabbix_host
+      server_url: https://localhost/zabbix
+      login_user: admin
+      login_password: "{{ zabbix_admin_pwd }}"
+      host_name: "{{ trix_ctrl_hostname }}.{{ trix_domain }}"
+      visible_name: "Controller{{ '\ HA' if ha else '' }}"
+      host_groups:
+        - Controller
+      link_templates:
+        - "CV role Controller{{ '\ HA' if ha else '' }}"
+      inventory_mode: disabled
+      interfaces:
+        - dns: "{{ trix_ctrl_hostname }}.{{ trix_domain }}"
+          ip: "{{ trix_ctrl_ip }}"
+          type: agent
+          main: 1
+          useip: 0
+          port: 10050
+      validate_certs: no
+
+  when: primary|default(True)
+        and ansible_connection not in 'lchroot'
+
+- block:
+  - name: Acquire zabbix Admin password (generate or use one from /etc/trinity/passwords)
+    set_fact:
+      zabbix_admin_pwd: "{{ lookup('password',
+                        '/etc/trinity/passwords/zabbix/admin.txt
+                         chars=ascii_letters,digits,hexdigits') }}"
+
+  - name: Ensure host group
+    local_action:
+      module: zabbix_group
+      server_url: https://localhost/zabbix
+      login_user: admin
+      login_password: "{{ zabbix_admin_pwd }}"
+      validate_certs: no
+      host_groups: "{{ image_name | capitalize }}"
+
+  - name: Ensure template
+    local_action:
+      module: zabbix_template
+      server_url: https://localhost/zabbix
+      login_user: admin
+      login_password: "{{ zabbix_admin_pwd }}"
+      validate_certs: no
+      template_name: "CV role {{ image_name | capitalize }}"
+     
+  - name: Get ID's
+    zabbix_conf:
+      username: "Admin"
+      password: "{{ zabbix_admin_pwd  }}"
+      hostname: "localhost"
+      validate_certs: no
+      proto: "https"
+      object: "{{ item.object }}"
+      action: "get"
+      filter: "{{ item.filter }}"
+    register: items
+    with_items:
+      - { object: "template", filter:  { host: "CV role {{ image_name | capitalize }}" } }
+      - { object: "hostgroup", filter: { name: "{{ image_name | capitalize }}" } }
+      - { object: "action", filter: { name: "Auto registration {{ image_name | capitalize }}" } }
+
+  - set_fact:
+      eventsource: 2
+    when: items.results.2.result.0 is undefined
 
   - name: Configure auto-registration
     zabbix_conf:
@@ -148,19 +203,20 @@
       validate_certs: no
       object: "action"
       action: "set"
-      filter:
-        name: "Auto registration"
       params:
+        name: "Auto registration {{ image_name | capitalize }}"
+        eventsource: "{{ eventsource | default(omit) }}"
+        filter:
+          evaltype: 0
+          conditions:
+            - conditiontype: 24
+              value: "{{ image_name }}"
         operations:
-          - actionid: 7
-            operationid: 13
-            operationtype: 6
+          - operationtype: 6
             optemplate:
-              - operationid: 13
-                templateid:  "{{ templates.results.1.result.0.templateid }}"
-              - operationid: 13
-                templateid:  "{{ templates.results.2.result.0.templateid }}"
-            recovery: 0
-
-  when: primary|default(True)
-        and ansible_connection not in 'lchroot'
+              - templateid: "{{ items.results.0.result.0.templateid }}"
+          - operationtype: 2
+          - operationtype: 4
+            opgroup:
+              - groupid: "{{ items.results.1.result.0.groupid }}"
+  when: ansible_connection in 'lchroot'

--- a/site/trinity-image-setup.yml
+++ b/site/trinity-image-setup.yml
@@ -79,10 +79,11 @@
       level: '*'
     tags: rsyslog
 
-  - role: trinity/zabbix_agent
-    tags: zabbix_agent
+#  - role: trinity/zabbix_agent
+#    tags: zabbix_agent
 
   - role: trinity/zabbix_checks
+    zabbix_hostmetadata: "{{ image_name }}"
     tags: zabbix_checks
 
   - role: trinity/docker


### PR DESCRIPTION
...based on HostMetadata set in zabbix_agentd.conf. The metadata is based
on the image_name variable. Auto-registered hosts are automatically
linked to the right template, see also the changes in the pull request
in trix-zabbix-checks.

Aligned the import path in zabbix_conf.py.
Fixed some spelling and style errors while I'm there.