### PR TITLE
tunables role

### DIFF
--- a/site/roles/trinity/tunables/handlers/main.yml
+++ b/site/roles/trinity/tunables/handlers/main.yml
@@ -2,4 +2,4 @@
 # handler file for tunables
 
 - name: activate sysctls
-  command: sysctl -p
+  command: sysctl --system


### PR DESCRIPTION
sysctl -p only reloads /etc/sysctl.conf, sysctl --system reloads all sysctl.d files.