### PR TITLE
Fix typo in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,8 +47,8 @@ Steps to install TrinityX
 
 6. Clone TrinityX repository into your working directory and go to the site directory::
 
-    # git clone http://github.com/clustervision/trinityx
-    # cd trinityx/site
+    # git clone http://github.com/clustervision/trinityX
+    # cd trinityX/site
 
 7. Based on whether you're installing a single-controller or a high-availability (HA) setup, you might want to update the configuration files:
 

--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ Steps to install TrinityX
 6. Clone TrinityX repository into your working directory and go to the site directory::
 
     # git clone http://github.com/clustervision/trinityx
-    # cd trinityX/site
+    # cd trinityx/site
 
 7. Based on whether you're installing a single-controller or a high-availability (HA) setup, you might want to update the configuration files:
 


### PR DESCRIPTION
After git clone, the cd should be into trinityx/site instead of trinityX/site