### PR TITLE
Remove RinohType extension from Sphinx's configuration

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -31,7 +31,7 @@
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'rinoh.frontend.sphinx',
+#    'rinoh.frontend.sphinx',
 #    'sphinx.ext.githubpages',
 ]
 


### PR DESCRIPTION
For the integration with readthedocs.io