### PR TITLE
Add codeready-builder-for-rhel-8-x86_64-rpms for RHEL8 compatibility.

### DIFF
--- a/site/roles/trinity/openhpc/tasks/main.yml
+++ b/site/roles/trinity/openhpc/tasks/main.yml
@@ -38,7 +38,7 @@
   yum:
     name: ohpc-base
     state: installed
-    enablerepo: powertools
+    enablerepo: powertools, codeready-builder-for-rhel-8-x86_64-rpms
   when: ansible_connection not in 'chroot'
 
 - name: Install ohpc-base-compute
@@ -64,7 +64,7 @@
     name:
       - lua-filesystem
       - lua-posix
-    enablerepo: powertools
+    enablerepo: powertools, codeready-builder-for-rhel-8-x86_64-rpms
     state: installed
   when: ansible_connection in 'chroot'
 
@@ -83,7 +83,7 @@
   yum:
     name: lmod-ohpc
     state: installed
-    enablerepo: powertools
+    enablerepo: powertools, codeready-builder-for-rhel-8-x86_64-rpms
 
 - name: Install profile for modules
   template:


### PR DESCRIPTION
Added codeready-builder-for-rhel-8-x86_64-rpms next to powertools for Red Hat 8 compatibility.